### PR TITLE
fix(docker): сборка падает — docker/nginx.conf исключён в .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@ node_modules/
 .*.env
 
 docker/
+!docker/nginx.conf
 .dockerignore
 
 docs/


### PR DESCRIPTION
При сборке Docker-образа `docker compose -f docker/docker-compose.yaml up` (как описано в README) сборка падает:

```
ERROR: failed to compute cache key: "/docker/nginx.conf": not found
```

## Причина

После переезда Docker-файлов в `docker/` (`chore: вынести Docker-файлы в docker/`):

- `docker/Dockerfile:26` делает `COPY docker/nginx.conf ...`
- контекст сборки — корень репозитория (`context: ..` в compose)
- но `.dockerignore` исключает всю папку `docker/`, поэтому `nginx.conf` отсутствует в контексте

## Фикс

Вернуть один нужный файл в контекст:

```
docker/
!docker/nginx.conf
.dockerignore
```

Остальное содержимое `docker/` (Dockerfile, compose) по-прежнему игнорируется — в контекст оно не нужно.

Проверено: с этой правкой `docker build -f docker/Dockerfile .` собирается успешно.